### PR TITLE
Feat detail page setup

### DIFF
--- a/src/routes/members/[id]/+page.svelte
+++ b/src/routes/members/[id]/+page.svelte
@@ -35,6 +35,7 @@
         aspect-ratio: 3/4;
         object-fit: cover;
         border-radius: .5em;
+        border: .3em solid #670f0f;
     }
 
     .book {
@@ -42,6 +43,7 @@
         grid-template-columns: 1fr;
         gap: 1rem;
     }
+
     .page {
         border: 6px solid rgb(52, 20, 6);
         border-radius: 1em;
@@ -51,12 +53,17 @@
     }
 
     @media (min-width: 720px) {
+        main {
+        perspective: 1000px;
+        }
         .book {
             grid-template-columns: 1fr 1fr;
              width: min(1000px, 95vw);
              position: relative;
+             transform-style: preserve-3d;
         }
-         .book::before {
+        /* book cover */
+        .book::before {
         content: "";
         position: absolute;
         top: 0;
@@ -66,6 +73,19 @@
         width: 12px;
         background: linear-gradient(#8a5e29, #4b361f);
         border-radius: .5em;
-    }
+        }
+        /* 3d effect book tilt */
+        .left {
+        transform: rotateY(-3deg);
+        }
+        .right {
+        transform: rotateY(3deg);
+        }
+        .book:hover .left {
+        transform: rotateY(-10deg);
+        }
+        .book:hover .right {
+        transform: rotateY(10deg);
+        }
 }
 </style>

--- a/src/routes/members/[id]/+page.svelte
+++ b/src/routes/members/[id]/+page.svelte
@@ -45,14 +45,27 @@
     .page {
         border: 6px solid rgb(52, 20, 6);
         border-radius: 1em;
-        background-color: white;
+        background: repeating-linear-gradient(0deg, transparent 0 22px, rgba(0, 0, 0, 0.262) 22px 23px),beige;
         padding: 1em;
+         box-shadow: 0 0 0 6px #5a432a, inset 0 0 0 2px #1e140a;
     }
 
     @media (min-width: 720px) {
         .book {
             grid-template-columns: 1fr 1fr;
              width: min(1000px, 95vw);
+             position: relative;
         }
+         .book::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 12px;
+        background: linear-gradient(#8a5e29, #4b361f);
+        border-radius: .5em;
     }
+}
 </style>

--- a/src/routes/members/[id]/+page.svelte
+++ b/src/routes/members/[id]/+page.svelte
@@ -53,6 +53,31 @@
         border: .3em solid #670f0f;
     }
 
+    a {
+        display: inline-block;
+        margin-top: 1.5rem;
+        padding: 0.6rem 1.2rem;
+        background-color: #670f0f; 
+        color: #fff;
+        text-decoration: none;
+        border-radius: 0.5em;
+        font-family: 'Harry Potter', sans-serif;
+        letter-spacing: 0.2em;
+        transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.3s ease;
+        box-shadow: 0 0 0 2px #670f0f, 0 4px 6px rgba(0,0,0,0.3);
+    }
+
+     a:hover {
+        transform: translateY(-3px) scale(1.05);
+        box-shadow: 0 0 10px #670f0f, 0 6px 12px rgba(0,0,0,0.4);
+        background: linear-gradient(45deg, #670f0f, #8c1515);
+    }
+
+    a:active {
+        transform: scale(0.95);
+        box-shadow: 0 0 6px #670f0f inset;
+    } 
+
     .book {
         display: grid;
         grid-template-columns: 1fr;
@@ -64,7 +89,7 @@
         border-radius: 1em;
         background: repeating-linear-gradient(0deg, transparent 0 22px, rgba(0, 0, 0, 0.262) 22px 23px),beige;
         padding: 1em;
-         box-shadow: 0 0 0 6px #5a432a, inset 0 0 0 2px #1e140a;
+        box-shadow: 0 0 0 6px #5a432a, inset 0 0 0 2px #1e140a;
     }
 
     @media (min-width: 720px) {

--- a/src/routes/members/[id]/+page.svelte
+++ b/src/routes/members/[id]/+page.svelte
@@ -14,7 +14,7 @@
         </article>
 
         <article class="page right">
-            <h2>{member.name}</h2>
+            <h2 class="type">{member.name}</h2>
             <p>{member.bio}</p>
             <a href="/members">Terug naar overzicht</a>
         </article>
@@ -101,5 +101,21 @@
         .book:hover .right {
         transform: rotateY(10deg);
         }
+        /* typewriter effect */
+        .type {
+        white-space: nowrap;
+        width: 0;
+        overflow: hidden;
+        border-right: 2px solid currentColor;
+        animation: typing 3.4s steps(28,end) forwards, caret .8s step-end infinite;
+        }
+
+        @keyframes typing {
+        to { width: 100% } 
+        }
+
+        @keyframes caret {
+        50% { border-color: transparent } 
+    }
 }
 </style>

--- a/src/routes/members/[id]/+page.svelte
+++ b/src/routes/members/[id]/+page.svelte
@@ -5,5 +5,18 @@
 </script>
 
 <!-- Hier wordt de data van de opgehaalde member getoond --> 
-    <h2>{member.name}</h2>
-    <a href="/">Terug naar overzicht</a>
+<main>
+    <div class="book">
+        <article class="page left">
+            <figure>
+                <img src={`https://fdnd.directus.app/assets/${member.mugshot}`} alt={member.name}/>
+            </figure>
+        </article>
+
+        <article class="page right">
+            <h2>{member.name}</h2>
+            <p>{member.bio}</p>
+            <a href="/members">Terug naar overzicht</a>
+        </article>
+    </div>
+</main>

--- a/src/routes/members/[id]/+page.svelte
+++ b/src/routes/members/[id]/+page.svelte
@@ -61,6 +61,20 @@
              width: min(1000px, 95vw);
              position: relative;
              transform-style: preserve-3d;
+             animation: float 3s ease-in-out infinite;
+        }
+        @keyframes float {
+            0% {
+                transform: translateY(0);
+            }
+
+            50% {
+                transform: translateY(-20px);
+            }
+
+            100% {
+                transform: translateY(0);
+            }
         }
         /* book cover */
         .book::before {

--- a/src/routes/members/[id]/+page.svelte
+++ b/src/routes/members/[id]/+page.svelte
@@ -20,3 +20,39 @@
         </article>
     </div>
 </main>
+
+<style>
+    main {
+    display: grid;
+    place-items: center;
+    background-color: rgb(255, 255, 255);
+    padding: 2rem;
+    min-height: 100vh;
+    }
+
+    img {
+        width: 100%;
+        aspect-ratio: 3/4;
+        object-fit: cover;
+        border-radius: .5em;
+    }
+
+    .book {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 1rem;
+    }
+    .page {
+        border: 6px solid rgb(52, 20, 6);
+        border-radius: 1em;
+        background-color: white;
+        padding: 1em;
+    }
+
+    @media (min-width: 720px) {
+        .book {
+            grid-template-columns: 1fr 1fr;
+             width: min(1000px, 95vw);
+        }
+    }
+</style>

--- a/src/routes/members/[id]/+page.svelte
+++ b/src/routes/members/[id]/+page.svelte
@@ -28,6 +28,21 @@
     background-color: rgb(255, 255, 255);
     padding: 2rem;
     min-height: 100vh;
+    background-image:
+    radial-gradient(circle at center, rgba(255,255,200,0.8) 0%, transparent 30%),
+    radial-gradient(circle at center, rgba(255,255,255,0.6) 0%, transparent 25%),
+    radial-gradient(circle at center, rgba(246, 240, 70, 0.7) 0%, transparent 30%),
+    radial-gradient(circle at center, rgba(227, 209, 12, 0.7) 0%, transparent 30%),
+    radial-gradient(circle at center, rgba(241, 240, 227, 0.7) 0%, transparent 30%);
+    background-repeat: no-repeat;
+    background-size: 400px 400px, 350px 350px, 500px 500px, 450px 450px;
+    animation: sparkles 15s linear infinite;
+    background-color: #110c1e;
+    }
+
+    @keyframes sparkles {
+        from { background-position: 0% 0%, 100% 100%, 50% 200%, -100% 50%; }
+        to   { background-position: 100% 50%, 0% 100%, 200% 0%, 50% -100%; }
     }
 
     img {

--- a/src/style.css
+++ b/src/style.css
@@ -47,6 +47,12 @@ html {
     background-color: var(--primary-bg-color),  var(--secondary-bg-color);
 }
 
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
 h1  {
     font-size: var(--h1-desktop);
     font-family: 'Harry Potter', sans-serif;


### PR DESCRIPTION
Ik heb de volledige member detailpagina gebouwd, met een book layout en animaties om mijn ontwerp te realiseren.
### Wat is er veranderd?

- Gewerkt aan [id]/+page.svelte detailpagina.
- HTML structuur opgezet.
- CSS book layout gemaakt (responsive, 1 kolom → 2 kolommen, 3D tilt)
- Animaties toegevoegd: floating book, typewriter-effect, background animation (gradient layers)
- Teruglink naar overzicht omgezet in een gestylede knop met hover interactie.

### Waarom?
Tot nu toe ontbrak er een detailpagina. Het doel is om memberprofielen een eigen plek en uitstraling te geven, in lijn met het Harry Potter thema van de site. Dit maakt de ervaring rijker en duidelijker voor gebruikers.

<img width="1470" height="790" alt="Scherm­afbeelding 2025-09-18 om 14 45 29" src="https://github.com/user-attachments/assets/8db494fa-281e-4385-ac94-0ca3aa5de331" />

### Gerelateerde issues
- Closes: #61 #62
- Gerelateerd aan: #60 

### Opmerkingen voor de reviewer
- Check of de animaties niet te druk zijn.
- Bevestig dat de navigatie terug naar /members klopt.